### PR TITLE
fix(authsync): run only once per session (temporary workaround)

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -8,9 +8,8 @@ import AuthSync from "./components/authentication/AuthSync";
 const App = () => {
   return (
     <>
-      {/* Need to get this to triger only once upon registration*/}
-      <AuthSync /> 
-      {/* Automatically runs when user logs in. syncs Auth0 user profile with user in mongoDB */}
+      {/* Will switch to Post-Login Action through Auth0 once project is deployed*/}
+      <AuthSync />  {/* Automatically runs when user logs in. syncs Auth0 user profile with user in mongoDB */}
       <RouterProvider router={router} />
       <Toaster />
     </>

--- a/FE/src/components/authentication/AuthSync.jsx
+++ b/FE/src/components/authentication/AuthSync.jsx
@@ -5,34 +5,34 @@ import { useEffect } from "react";
 
 // This syncs the user profile information from the Auth0 ID token with MongoDB users
 //If user doesn't exist (i.e. on user's first sign-up/login) in the mongoDB, a new user is created with the profle information from Auth0
+// Will run on each login
 const AuthSync = () => {
     const { user, isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0();
-    // const hasSynced = sessionStorage.getItem("hasSynced");
-        // Attempt to make sync happen only once per session
-    // const hasSyncedRef = useRef(false); 
-        // Attempt to make sync happen only once after login
 
     useEffect(() => {
         if (isLoading || !isAuthenticated) return;
-        // if (isLoading || !isAuthenticated || hasSynced === "true") return; 
-            //Attempt to make sync happen only once per session
-        // if (isLoading || !isAuthenticated || hasSyncedRef.current) return;
-            // Attempt to make sync happen only once after login
 
+        const hasSynced = sessionStorage.getItem("hasSynced");
+        
         const runSync = async () => {
             try {
                 const token = await getAccessTokenSilently();
-                console.log("USER = ", user);
                 await syncUser(token, user);
-                console.log("user synced once this session");
-                // hasSynced.setItem("hasSynced", "true"); //Attempt to make sync happen only once per session
-                // hasSyncedRef.current = true; //Attempt to make sync happen only once after login
+                sessionStorage.setItem("hasSynced", true)
+                //sessionStorage is now cleared on logout in LogoutButton component
+                console.log("user synced once this session", hasSynced);
+                
             } catch (error) {
                 console.error("user sync failed: ", error);
             }
         };
 
-        runSync();
+        // Prevents full component from running each page render - only checks sessionStorage on renders after login
+        if (!hasSynced) {
+            runSync();
+        } else {
+            console.log("User already synced");
+        }
 
     }, [user, isLoading, isAuthenticated, getAccessTokenSilently]);
     

--- a/FE/src/components/authentication/LogoutButton.jsx
+++ b/FE/src/components/authentication/LogoutButton.jsx
@@ -14,7 +14,13 @@ const LogoutButton = ({ colorPalette, size, variant, fontWeight, alignContent })
       variant={variant}
       fontWeight={fontWeight}
       alignContent={alignContent}
-      onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+      // onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+      onClick={
+        () => {
+          logout({ logoutParams: { returnTo: window.location.origin } });
+          sessionStorage.clear();
+        }
+      }
     >
       Log Out
     </Button>

--- a/FE/src/pages/UserAccount.jsx
+++ b/FE/src/pages/UserAccount.jsx
@@ -9,7 +9,6 @@ import { toaster } from "@/components/ui/toaster";
 import { useEffect, useState } from "react";
 import { getUser, patchUserProfile } from "../services/userService";
 
-import LogoutButton from "../components/authentication/LogoutButton";
 import UserAccountView from "../components/user/UserAccountView";
 import UserAccountForm from "../components/user/UserAccountForm";
 
@@ -26,19 +25,34 @@ const UserAccount = () => {
       return;
     }
 
-    getAccessTokenSilently()
-    .then((token) => {
-      return getUser(token);
-    })
-    .then((res) => {
-      setDbUser(res.data.user);
-      setLoading(false);
-      console.log("User fetched:", res.data);
-    })
-    .catch((error) => {
-      console.log("Error fetching user: ", error);
-      setLoading(false);
-    })
+    const fetchUser = async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const res = await getUser(token);
+        setDbUser(res.data.user);
+        setLoading(false);
+        console.log("User fetched:", res.data);
+      } catch (error) {
+        console.error("Error fetching user: ", error);
+        setLoading(false);
+      }
+    }
+
+    fetchUser();
+
+    // getAccessTokenSilently()
+    // .then((token) => {
+    //   return getUser(token);
+    // })
+    // .then((res) => {
+    //   setDbUser(res.data.user);
+    //   setLoading(false);
+    //   console.log("User fetched:", res.data);
+    // })
+    // .catch((error) => {
+    //   console.log("Error fetching user: ", error);
+    //   setLoading(false);
+    // })
   }, [authIsLoading, getAccessTokenSilently]);
 
   const handleUpdate = async (updateData) => {


### PR DESCRIPTION
- sets `sessionStorage.setItem("hasSynced", "true")` after successful sync
- `LogoutButton` now clears the flag so the next login triggers a fresh sync
- stops duplicate `/api/users/sync` calls on every route change
- **Note:** temporary fix until Auth0 post_login Action is in place after deployment